### PR TITLE
fix: 修复 npm dev 时报错 line-clamp-2 未找到的问题

### DIFF
--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -65,5 +65,6 @@ module.exports = {
   },
   plugins: [
     require('@tailwindcss/typography'),
+    require('@tailwindcss/line-clamp'),
   ],
 }


### PR DESCRIPTION
报错文件: app\(commonLayout)\list.module.css:99:3
原因: tailwind@3.3之前, line-clamp 未包含在默认框架中, 需手动引入